### PR TITLE
Switch cache keys metrics to point tags

### DIFF
--- a/internal/app/cache/cache_test.go
+++ b/internal/app/cache/cache_test.go
@@ -92,10 +92,12 @@ func TestAddRequestAndFetch(t *testing.T) {
 
 	err = cache.AddRequest(testKeyA, &testRequestA)
 	assert.NoError(t, err)
-	testutils.AssertCounterValue(
-		t, mockScope.Snapshot().Counters(), fmt.Sprintf("cache.%s.add_request.attempt", testKeyA), 1)
-	testutils.AssertCounterValue(
-		t, mockScope.Snapshot().Counters(), fmt.Sprintf("cache.%s.add_request.success", testKeyA), 1)
+	countersSnapshot := mockScope.Snapshot().Counters()
+	fmt.Println(countersSnapshot)
+	assert.EqualValues(
+		t, 1, countersSnapshot[fmt.Sprintf("cache.add_request.attempt+key=%v", testKeyA)].Value())
+	assert.EqualValues(
+		t, 1, countersSnapshot[fmt.Sprintf("cache.add_request.success+key=%v", testKeyA)].Value())
 
 	resource, err = cache.Fetch(testKeyA)
 	assert.NoError(t, err)

--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -5,6 +5,8 @@ import (
 	"github.com/uber-go/tally"
 )
 
+const TagName = "key"
+
 // .server
 const (
 	// scope: .server.*
@@ -133,10 +135,11 @@ func CacheSetSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
 	return parent.SubScope(aggregatedKey).SubScope(ScopeCacheSet)
 }
 
-// CacheAddRequestSubscope gets the cache add request subscope for the aggregated key.
-// ex: .cache.$aggregated_key.add_request
+// CacheAddRequestSubscope gets the cache add request subscope and adds the the aggregated key
+// as a point tag.
+// ex: .cache.add_request+key=$aggregated_key
 func CacheAddRequestSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
-	return parent.SubScope(ScopeCacheAdd).Tagged(map[string]string{"key": aggregatedKey})
+	return parent.SubScope(ScopeCacheAdd).Tagged(map[string]string{TagName: aggregatedKey})
 }
 
 // CacheDeleteRequestSubscope gets the cache delete request subscope for the aggregated key.

--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -129,21 +129,22 @@ func CacheFetchSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
 	return parent.SubScope(aggregatedKey).SubScope(ScopeCacheFetch)
 }
 
-// CacheSetSubscope gets the cache set subscope for the aggregated key.
-// ex: .cache.$aggregated_key.set_response
+// CacheSetSubscope gets the cache set subscope and adds the aggregated key as a point tag.
+// ex: .cache.set_response+key=$aggregated_key
 func CacheSetSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
-	return parent.SubScope(aggregatedKey).SubScope(ScopeCacheSet)
+	return parent.SubScope(ScopeCacheSet).Tagged(map[string]string{TagName: aggregatedKey})
 }
 
-// CacheAddRequestSubscope gets the cache add request subscope and adds the the aggregated key
+// CacheAddRequestSubscope gets the cache add request subscope and adds the aggregated key
 // as a point tag.
 // ex: .cache.add_request+key=$aggregated_key
 func CacheAddRequestSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
 	return parent.SubScope(ScopeCacheAdd).Tagged(map[string]string{TagName: aggregatedKey})
 }
 
-// CacheDeleteRequestSubscope gets the cache delete request subscope for the aggregated key.
-// ex: .cache.$aggregated_key.delete_request
+// CacheDeleteRequestSubscope gets the cache delete request subscope and adds the aggregated key
+// as a point tag.
+// ex: .cache.delete_request+key=$aggregated_key
 func CacheDeleteRequestSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
-	return parent.SubScope(aggregatedKey).SubScope(ScopeCacheDelete)
+	return parent.SubScope(ScopeCacheDelete).Tagged(map[string]string{TagName: aggregatedKey})
 }

--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -105,22 +105,25 @@ const (
 	ErrorInterceptorErrorRecvMsg = "error_recvmsg"
 )
 
-// OrchestratorWatchSubscope gets the orchestor watch subscope for the aggregated key.
-// ex: .orchestrator.$aggregated_key.watch
+// OrchestratorWatchSubscope gets the orchestor watch subscope and adds the aggregated key as a point tag.
+// ex: .orchestrator.watch+key=$aggregated_key
 func OrchestratorWatchSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
-	return parent.SubScope(aggregatedKey).SubScope(ScopeOrchestratorWatch)
+	return parent.SubScope(ScopeOrchestratorWatch).Tagged(map[string]string{TagName: aggregatedKey})
 }
 
-// OrchestratorWatchErrorsSubscope gets the orchestor watch errora subscope for the aggregated key.
-// ex: .orchestrator.$aggregated_key.watch.errors
+// OrchestratorWatchErrorsSubscope gets the orchestor watch errors subscope and adds the aggregated key
+// as a point tag.
+// ex: .orchestrator.watch.errors+key=$aggregated_key.
 func OrchestratorWatchErrorsSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
-	return parent.SubScope(aggregatedKey).SubScope(ScopeOrchestratorWatch).SubScope(ScopeOrchestratorWatchErrors)
+	watchErrorsSubScope := parent.SubScope(ScopeOrchestratorWatch).SubScope(ScopeOrchestratorWatchErrors)
+	return watchErrorsSubScope.Tagged(map[string]string{TagName: aggregatedKey})
 }
 
-// OrchestratorCacheEvictSubscope gets the orchestor cache evict subscope for the aggregated key.
-// ex: .orchestrator.$aggregated_key.cache_evict
+// OrchestratorCacheEvictSubscope gets the orchestor cache evict subscope and adds the aggregated key
+// as a point tag.
+// ex: .orchestrator.cache_evict+key=$aggregated_key.
 func OrchestratorCacheEvictSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
-	return parent.SubScope(aggregatedKey).SubScope(ScopeOrchestratorCacheEvict)
+	return parent.SubScope(ScopeOrchestratorCacheEvict).Tagged(map[string]string{TagName: aggregatedKey})
 }
 
 // CacheFetchSubscope gets the cache fetch subscope and adds the aggregated key as a point tag.

--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -136,7 +136,7 @@ func CacheSetSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
 // CacheAddRequestSubscope gets the cache add request subscope for the aggregated key.
 // ex: .cache.$aggregated_key.add_request
 func CacheAddRequestSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
-	return parent.SubScope(aggregatedKey).SubScope(ScopeCacheAdd)
+	return parent.SubScope(ScopeCacheAdd).Tagged(map[string]string{"key": aggregatedKey})
 }
 
 // CacheDeleteRequestSubscope gets the cache delete request subscope for the aggregated key.

--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -123,10 +123,10 @@ func OrchestratorCacheEvictSubscope(parent tally.Scope, aggregatedKey string) ta
 	return parent.SubScope(aggregatedKey).SubScope(ScopeOrchestratorCacheEvict)
 }
 
-// CacheFetchSubscope gets the cache fetch subscope for the aggregated key.
-// ex: .cache.$aggregated_key.fetch
+// CacheFetchSubscope gets the cache fetch subscope and adds the aggregated key as a point tag.
+// ex: .cache.fetch+key=$aggregated_key
 func CacheFetchSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
-	return parent.SubScope(aggregatedKey).SubScope(ScopeCacheFetch)
+	return parent.SubScope(ScopeCacheFetch).Tagged(map[string]string{TagName: aggregatedKey})
 }
 
 // CacheSetSubscope gets the cache set subscope and adds the aggregated key as a point tag.

--- a/internal/app/orchestrator/orchestrator_test.go
+++ b/internal/app/orchestrator/orchestrator_test.go
@@ -136,8 +136,9 @@ func TestGoldenPath(t *testing.T) {
 	assert.NoError(t, err)
 
 	respChannel, cancelWatch := orchestrator.CreateWatch(req)
-	testutils.AssertCounterValue(t, mockScope.Snapshot().Counters(),
-		fmt.Sprintf("mock_orchestrator.%s.watch.created", aggregatedKey), 1)
+	countersSnapshot := mockScope.Snapshot().Counters()
+	assert.EqualValues(
+		t, 1, countersSnapshot[fmt.Sprintf("mock_orchestrator.watch.created+key=%v", aggregatedKey)].Value())
 	assert.NotNil(t, respChannel)
 	assert.Equal(t, 1, len(orchestrator.downstreamResponseMap.responseChannels))
 	testutils.AssertSyncMapLen(t, 1, orchestrator.upstreamResponseMap.internal)
@@ -167,10 +168,11 @@ func TestGoldenPath(t *testing.T) {
 
 	cancelWatch()
 
-	testutils.AssertCounterValue(t, mockScope.Snapshot().Counters(),
-		fmt.Sprintf("mock_orchestrator.%s.watch.fanout", aggregatedKey), 1)
-	testutils.AssertCounterValue(t, mockScope.Snapshot().Counters(),
-		fmt.Sprintf("mock_orchestrator.%s.watch.canceled", aggregatedKey), 1)
+	countersSnapshot = mockScope.Snapshot().Counters()
+	assert.EqualValues(
+		t, 1, countersSnapshot[fmt.Sprintf("mock_orchestrator.watch.fanout+key=%v", aggregatedKey)].Value())
+	assert.EqualValues(
+		t, 1, countersSnapshot[fmt.Sprintf("mock_orchestrator.watch.canceled+key=%v", aggregatedKey)].Value())
 	assert.Equal(t, 0, len(orchestrator.downstreamResponseMap.responseChannels))
 }
 


### PR DESCRIPTION
This PR builds on top of https://github.com/envoyproxy/xds-relay/pull/126 replacing the subscopes containing the aggregation key as part of the metric name for metric where the aggregation key becomes a point tag. 

For example, previously we'd emit the counter "xdsrelay.cache.cluster1-key.fetch.attempt" but now we're going to emit the metric as "xdsrelay.cache.fetch.attempt+key=cluster1-key" where the syntax "+key=cluster1-key" means a point tag named "key" with value "cluster1-key".